### PR TITLE
fix: bound audio decode with dedicated semaphore to prevent host-RAM OOM

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -61,3 +61,11 @@ class CONFIG:
     # Concurrent transcription operations. faster-whisper is lighter than vocal separation;
     # can be set higher than VOCALS_CONCURRENCY to improve pipeline throughput.
     TRANSCRIBE_CONCURRENCY = int(os.getenv("TRANSCRIBE_CONCURRENCY", os.getenv("GPU_CONCURRENCY", 1)))
+
+    # Concurrent audio decode/preprocess operations. This is CPU + host-RAM bound, NOT GPU,
+    # and it is what drives host-RAM OOMs: each decode holds the whole clip as a float32
+    # numpy array (~230 MB per hour of audio), plus transient copies during conversion.
+    # It must be capped independently of the GPU semaphores — otherwise N concurrent uploads
+    # decode N full clips into RAM at once even when TRANSCRIBE_CONCURRENCY is 1.
+    # ponytail: fixed cap on concurrent decodes; raise per available host RAM, not per GPU.
+    DECODE_CONCURRENCY = int(os.getenv("DECODE_CONCURRENCY", os.getenv("GPU_CONCURRENCY", 2)))

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -38,6 +38,9 @@ logger = logging.getLogger(__name__)
 # Both default to GPU_CONCURRENCY for backwards compatibility.
 _vocals_semaphore    = asyncio.Semaphore(CONFIG.VOCALS_CONCURRENCY)
 _transcribe_semaphore = asyncio.Semaphore(CONFIG.TRANSCRIBE_CONCURRENCY)
+# Caps host-RAM use: decode holds the full clip as a float32 array (~230 MB/hour).
+# Without this gate, concurrent uploads decode all clips into RAM at once and OOM the host.
+_decode_semaphore    = asyncio.Semaphore(CONFIG.DECODE_CONCURRENCY)
 
 _start_time = time.time()
 _requests_total = 0
@@ -240,12 +243,14 @@ async def asr(
                     newrelic.agent.FunctionTrace(name="asr.separate_vocals", group="ASR"),
                     timer("separate_vocals", enabled=verbose),
                 ):
-                    # CPU phase: decode audio and fetch cached model — no GPU needed
-                    audio_raw, vs_cfg, vs_model, vs_device = await asyncio.to_thread(
-                        load_audio_for_separation,
-                        in_path,
-                        model_id=CONFIG.VOICE_SEPARATION_MODEL,
-                    )
+                    # CPU phase: decode audio and fetch cached model — no GPU needed.
+                    # Decode is the RAM-heavy step, so it goes under the decode gate.
+                    async with _decode_semaphore:
+                        audio_raw, vs_cfg, vs_model, vs_device = await asyncio.to_thread(
+                            load_audio_for_separation,
+                            in_path,
+                            model_id=CONFIG.VOICE_SEPARATION_MODEL,
+                        )
                     # GPU phase: vocal separation inference
                     async with _vocals_semaphore:
                         await asyncio.to_thread(
@@ -263,7 +268,8 @@ async def asr(
                         newrelic.agent.FunctionTrace(name="asr.load_audio_vocals", group="ASR"),
                         timer("load_audio(vocals)", enabled=verbose),
                     ):
-                        audio_np = await asyncio.to_thread(load_audio, f_vocals, encode=True)
+                        async with _decode_semaphore:
+                            audio_np = await asyncio.to_thread(load_audio, f_vocals, encode=True)
 
                 with (
                     newrelic.agent.FunctionTrace(name="asr.transcribe", group="ASR"),
@@ -286,7 +292,8 @@ async def asr(
             newrelic.agent.FunctionTrace(name="asr.load_audio_original", group="ASR"),
             timer("load_audio(original)", enabled=verbose),
         ):
-            audio_np = await asyncio.to_thread(load_audio, audio_file.file, encode)
+            async with _decode_semaphore:
+                audio_np = await asyncio.to_thread(load_audio, audio_file.file, encode)
 
         with (
             newrelic.agent.FunctionTrace(name="asr.total_after_decode", group="ASR"),

--- a/tests/test_asr_async.py
+++ b/tests/test_asr_async.py
@@ -4,6 +4,7 @@ and do not block the async event loop.
 """
 import asyncio
 import io
+import time
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -124,6 +125,47 @@ def test_asr_response_contains_transcription(client):
 # ---------------------------------------------------------------------------
 # Behavior: /detect-language returns language and confidence
 # ---------------------------------------------------------------------------
+
+
+def test_decode_concurrency_is_bounded(client):
+    """Concurrent /asr uploads must not decode more clips at once than DECODE_CONCURRENCY,
+    even though transcription is serialized by a separate (smaller) semaphore. This is the
+    host-RAM guard: without it, N concurrent decodes hold N full audio arrays in RAM."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    c, model = client
+    model.transcribe.return_value = io.StringIO("hello world")
+
+    import app.webservice as ws
+    limit = ws._decode_semaphore._value  # initial = CONFIG.DECODE_CONCURRENCY
+
+    lock = threading.Lock()
+    state = {"now": 0, "max": 0}
+
+    def blocking_load_audio(*_args, **_kwargs):
+        with lock:
+            state["now"] += 1
+            state["max"] = max(state["max"], state["now"])
+        time.sleep(0.1)  # hold the decode slot so overlap is observable
+        with lock:
+            state["now"] -= 1
+        return FAKE_AUDIO_NP
+
+    def fire():
+        return c.post(
+            "/asr",
+            files={"audio_file": ("audio.wav", io.BytesIO(FAKE_AUDIO), "audio/wav")},
+        )
+
+    with patch("app.webservice.load_audio", side_effect=blocking_load_audio):
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = [f.result() for f in [pool.submit(fire) for _ in range(8)]]
+
+    assert all(r.status_code == 200 for r in results)
+    assert state["max"] <= limit, f"decode concurrency {state['max']} exceeded cap {limit}"
+    if limit > 1:
+        assert state["max"] > 1, "decode never ran in parallel; cap is not just serializing"
 
 
 def test_detect_language_returns_language_and_confidence(client):


### PR DESCRIPTION
## Problem

Production OOM kill (`whisper-asr-web`, anon-rss ~7.2 GB on an 8 GB host, no swap, container with no memory limit). This is a **host-RAM** OOM, not VRAM.

Root cause: the GPU semaphores (`_transcribe_semaphore`, `_vocals_semaphore`) only gate inference. Audio **decode** ran *ahead* of them with no cap:

- `load_audio` in the normal path
- `load_audio_for_separation` (CPU phase) and `load_audio(vocals)` in the separate-vocals path

Each decode holds the whole clip as a float32 numpy array (~230 MB per hour of audio) plus transient copies. With FastAPI accepting unbounded concurrent requests and `asyncio.to_thread` using a ~32-thread pool, N concurrent uploads decode N full clips into RAM simultaneously — **even with `TRANSCRIBE_CONCURRENCY=1`**. A handful of multi-hour clips → ~7 GB → OOM.

## Fix

- New `DECODE_CONCURRENCY` config (env `DECODE_CONCURRENCY`, falls back to `GPU_CONCURRENCY`, default **2**) — CPU/host-RAM bound, independent of the GPU.
- New `_decode_semaphore` gating the three decode stages. GPU steps (`run_separation_gpu`, `transcribe`) stay outside the decode gate, so decode and inference parallelism are controlled but decoupled.

## Test

`test_decode_concurrency_is_bounded`: fires 8 concurrent `/asr` requests, asserts max simultaneous decodes ≤ `DECODE_CONCURRENCY` and > 1 (real parallelism, not serialization). 6 passed.

## Deploy note (not in this PR)

Also recommend a container `mem_limit` and `uvicorn --limit-concurrency` as a safety net — deployment config, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)