### PR TITLE
perf: halve transient RAM per decode in load_audio

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -129,7 +129,12 @@ def load_audio(file: BinaryIO, encode=True, sr: int = CONFIG.SAMPLE_RATE):
     else:
         out = file.read()
 
-    return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    # frombuffer is a 1-D view (no copy); astype makes the single float32 copy we keep,
+    # then normalize in place. Avoids the extra flatten() copy and the division temporary —
+    # peak transient RAM per decode drops from ~6x to ~3x the PCM size.
+    audio = np.frombuffer(out, np.int16).astype(np.float32)
+    audio /= 32768.0
+    return audio
 
 
 @contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+"""Unit tests for app.utils.load_audio numeric conversion."""
+import io
+
+import numpy as np
+
+from app.utils import load_audio
+
+
+def test_load_audio_converts_int16_to_normalized_float32():
+    """encode=False path: int16 PCM bytes -> 1-D float32 array normalized to [-1, 1)."""
+    samples = np.array([0, 32767, -32768, 16384], dtype=np.int16)
+    out = load_audio(io.BytesIO(samples.tobytes()), encode=False)
+
+    assert out.dtype == np.float32
+    assert out.ndim == 1
+    np.testing.assert_allclose(
+        out, samples.astype(np.float32) / 32768.0, rtol=0, atol=0
+    )


### PR DESCRIPTION
## What

`load_audio` converted decoded PCM with:

```python
np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
```

That materializes ~6 copies of the audio at peak: the PCM bytes (`out`), a redundant `flatten()` copy, the `float32` copy, and the division temporary. For multi-hour clips (Mediainbox broadcasts) that's hundreds of MB of transient RAM **per decode**, and it stacks under concurrency.

## Change

```python
audio = np.frombuffer(out, np.int16).astype(np.float32)
audio /= 32768.0
return audio
```

`frombuffer` already returns a 1-D view, so `flatten()` is dropped; `astype` makes the single float32 copy we keep, normalized in place. Peak transient RAM drops from ~6x to ~3x the PCM size, identical output.

Companion to the host-RAM OOM fix in #11 (bounded decode concurrency); independent and mergeable on its own.

## Test

`tests/test_utils.py::test_load_audio_converts_int16_to_normalized_float32` — verifies dtype, 1-D shape, and exact normalized values via the `encode=False` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)