### PR TITLE
feat: extend /stats with decode slots, OS metrics and richer GPU info

### DIFF
--- a/app/webservice.py
+++ b/app/webservice.py
@@ -104,6 +104,48 @@ async def health():
     return {"status": "ok"}
 
 
+def _os_metrics():
+    """Best-effort host/process metrics. Linux /proc + stdlib only; returns whatever is
+    available (so it degrades to load_avg-only on non-Linux dev machines). These surface
+    the host-RAM OOM signals directly: memory.available_mib, swap, and process.rss_mib."""
+    m = {}
+    try:
+        m["cpu_count"] = os.cpu_count()
+        m["load_avg"] = [round(x, 2) for x in os.getloadavg()]
+    except (OSError, AttributeError):
+        pass
+    try:
+        info = {}
+        with open("/proc/meminfo") as f:
+            for line in f:
+                key, _, rest = line.partition(":")
+                info[key] = int(rest.split()[0])  # values in kB
+        total = info["MemTotal"]
+        available = info.get("MemAvailable", info.get("MemFree", 0))
+        m["memory"] = {
+            "total_mib": round(total / 1024),
+            "available_mib": round(available / 1024),
+            "used_mib": round((total - available) / 1024),
+            "percent_used": round(100 * (total - available) / total, 1) if total else None,
+            "swap_total_mib": round(info.get("SwapTotal", 0) / 1024),
+            "swap_free_mib": round(info.get("SwapFree", 0) / 1024),
+        }
+    except (OSError, KeyError, ValueError):
+        pass
+    try:
+        proc = {}
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith(("VmRSS:", "VmSize:")):
+                    key, _, rest = line.partition(":")
+                    proc[key] = round(int(rest.split()[0]) / 1024)  # kB -> MiB
+        if proc:
+            m["process"] = {"rss_mib": proc.get("VmRSS"), "vm_mib": proc.get("VmSize")}
+    except (OSError, ValueError):
+        pass
+    return m
+
+
 @app.get("/stats", tags=["Health"], include_in_schema=False)
 async def stats():
     import torch
@@ -111,13 +153,30 @@ async def stats():
     if torch.cuda.is_available():
         for i in range(torch.cuda.device_count()):
             props = torch.cuda.get_device_properties(i)
-            gpu.append({
+            entry = {
                 "index": i,
                 "name": props.name,
                 "memory_allocated_mib": round(torch.cuda.memory_allocated(i) / 1024 ** 2),
                 "memory_reserved_mib": round(torch.cuda.memory_reserved(i) / 1024 ** 2),
                 "memory_total_mib": round(props.total_memory / 1024 ** 2),
-            })
+            }
+            # Actual device memory (not just torch's caching allocator view) + util/temp.
+            # ponytail: best-effort — util/temp need pynvml under the hood and may be absent.
+            try:
+                free, total = torch.cuda.mem_get_info(i)
+                entry["memory_free_mib"] = round(free / 1024 ** 2)
+                entry["memory_used_mib"] = round((total - free) / 1024 ** 2)
+            except Exception:
+                pass
+            try:
+                entry["utilization_percent"] = torch.cuda.utilization(i)
+            except Exception:
+                pass
+            try:
+                entry["temperature_c"] = torch.cuda.temperature(i)
+            except Exception:
+                pass
+            gpu.append(entry)
 
     return {
         "uptime_seconds": round(time.time() - _start_time),
@@ -133,6 +192,11 @@ async def stats():
             "loaded": asr_model.model is not None,
             "idle_seconds": round(time.time() - asr_model.last_activity_time),
         },
+        "decode": {
+            "concurrency": CONFIG.DECODE_CONCURRENCY,
+            "slots_used": CONFIG.DECODE_CONCURRENCY - _decode_semaphore._value,
+            "slots_free": _decode_semaphore._value,
+        },
         "transcribe": {
             "concurrency": CONFIG.TRANSCRIBE_CONCURRENCY,
             "slots_used": CONFIG.TRANSCRIBE_CONCURRENCY - _transcribe_semaphore._value,
@@ -143,6 +207,7 @@ async def stats():
             "slots_used": CONFIG.VOCALS_CONCURRENCY - _vocals_semaphore._value,
             "slots_free": _vocals_semaphore._value,
         },
+        "os": _os_metrics(),
         "gpu": gpu,
     }
 

--- a/tests/test_asr_async.py
+++ b/tests/test_asr_async.py
@@ -168,6 +168,29 @@ def test_decode_concurrency_is_bounded(client):
         assert state["max"] > 1, "decode never ran in parallel; cap is not just serializing"
 
 
+def test_stats_exposes_decode_os_and_gpu(client):
+    """/stats must expose the decode semaphore block, OS metrics, and a gpu list."""
+    from app.config import CONFIG
+
+    c, _ = client
+    response = c.get("/stats")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    # decode block mirrors transcribe/vocals and reflects the dedicated semaphore
+    assert body["decode"]["concurrency"] == CONFIG.DECODE_CONCURRENCY
+    assert body["decode"]["slots_used"] == 0  # idle: nothing decoding
+    assert body["decode"]["slots_free"] == CONFIG.DECODE_CONCURRENCY
+
+    # OS metrics present and best-effort (load_avg works cross-platform)
+    assert isinstance(body["os"], dict)
+    assert "load_avg" in body["os"]
+
+    # gpu list present (empty when cuda unavailable, as in tests)
+    assert isinstance(body["gpu"], list)
+
+
 def test_detect_language_returns_language_and_confidence(client):
     """/detect-language must return detected_language, language_code, and confidence."""
     c, model = client


### PR DESCRIPTION
Stacked on #11 (base will retarget to `main` once #11 merges).

## What

Extends `/stats` so it surfaces the signals behind the host-RAM OOM, not just GPU allocator numbers.

**`decode` block** — `concurrency` / `slots_used` / `slots_free` for the new decode semaphore (#11), mirroring the existing `transcribe` and `vocals` blocks. Lets you watch decode saturation live.

**`os` block** — host CPU count, load average, memory (total / available / used / percent + swap), and process RSS / VmSize. Read from `/proc` + stdlib, **no new dependencies**. Best-effort: degrades to `load_avg` only on non-Linux dev machines. These are the exact fields the OOM log showed: `memory.available_mib` and `process.rss_mib` (the 7.2 GB that got killed; `vm_mib` is the 62 GB virtual red herring).

**`gpu` entries** — real device memory via `torch.cuda.mem_get_info` (`memory_free_mib` / `memory_used_mib`, the actual device state vs. torch's caching-allocator view), plus best-effort `utilization_percent` and `temperature_c` (guarded; need pynvml under the hood).

## Example shape

```jsonc
{
  "decode":     { "concurrency": 2, "slots_used": 1, "slots_free": 1 },
  "transcribe": { "concurrency": 1, "slots_used": 1, "slots_free": 0 },
  "os": {
    "cpu_count": 4,
    "load_avg": [1.2, 0.9, 0.7],
    "memory": { "total_mib": 8192, "available_mib": 512, "used_mib": 7680,
                "percent_used": 93.8, "swap_total_mib": 0, "swap_free_mib": 0 },
    "process": { "rss_mib": 7050, "vm_mib": 61300 }
  },
  "gpu": [ { "index": 0, "memory_free_mib": 1200, "memory_used_mib": 14000,
             "utilization_percent": 87, "temperature_c": 71 } ]
}
```

## Test

`test_stats_exposes_decode_os_and_gpu`: asserts the `decode` block reflects `DECODE_CONCURRENCY` (idle → all slots free), `os` is present with `load_avg`, and `gpu` is a list. Full suite: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)