### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ Changelog
 Unreleased
 ----------
 
+[2.4.0] (2026-06-26)
+--------------------
+
+### Fixed
+
+- Host-RAM OOM under concurrent load: audio decode now runs under a dedicated
+  `DECODE_CONCURRENCY` semaphore (default 2), so concurrent uploads no longer
+  decode an unbounded number of full clips into RAM ahead of the GPU semaphores.
+
+### Changed
+
+- `load_audio` converts decoded PCM with an in-place normalization and without the
+  redundant `flatten()` copy, cutting peak transient RAM per decode from ~6x to ~3x
+  the PCM size.
+
+### Added
+
+- `DECODE_CONCURRENCY` env var (falls back to `GPU_CONCURRENCY`) to cap concurrent
+  audio decodes independently of GPU inference.
+- `/stats` now reports the `decode` semaphore slots, host `os` metrics (CPU count,
+  load average, memory + swap, process RSS/VmSize, from `/proc` + stdlib), and
+  richer per-GPU info (real device free/used memory via `mem_get_info`, plus
+  best-effort utilization and temperature).
+
 [1.9.1] (2025-07-01)
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-asr-webservice"
-version = "2.3.0"
+version = "2.4.0"
 description = "Whisper ASR Webservice is a general-purpose speech recognition webservice."
 requires-python = ">=3.10,<3.13"
 dependencies = [


### PR DESCRIPTION
Release **2.4.0** — bumps `pyproject` version and adds the CHANGELOG entry for the host-RAM OOM work already merged to `main`:

- Decode concurrency semaphore (host-RAM OOM fix)
- `load_audio` fewer copies (~6x→3x transient RAM per decode)
- `/stats` extended with decode slots + OS/GPU metrics

Merging this and pushing the `v2.4.0` tag triggers `docker-publish.yml`, which builds and pushes `:v2.4.0` / `:v2.4.0-gpu` (and `:latest` / `:latest-gpu`) to DockerHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)