### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ Changelog
 Unreleased
 ----------
 
-[2.4.0] (2026-06-26)
+[2.5.0] (2026-06-26)
 --------------------
+
+> Released as 2.5.0 (not 2.4.x) to stay ahead of the existing `v2.4.5` container tag in the registry.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-asr-webservice"
-version = "2.4.0"
+version = "2.5.0"
 description = "Whisper ASR Webservice is a general-purpose speech recognition webservice."
 requires-python = ">=3.10,<3.13"
 dependencies = [


### PR DESCRIPTION
Renumbers the host-RAM OOM release from 2.4.0 to **2.5.0** so the version is unambiguously ahead of the pre-existing `v2.4.5` container tag in Artifact Registry. Same content as 2.4.0 (decode semaphore OOM fix, load_audio fewer copies, /stats OS+GPU metrics); only the version label changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)