### PR TITLE
perf(vocals): make separation VRAM O(1) in clip duration (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changelog
 Unreleased
 ----------
 
+[2.5.1] (2026-06-28)
+--------------------
+
+### Fixed
+
+- Vocal separation VRAM scaled with clip length: the whole mix was moved to the GPU at once
+  (`~2.5 GB of VRAM for a 2 h stereo clip` before any inference), causing CUDA out-of-memory
+  on long files. Each chunk is now moved to the GPU one at a time, so VRAM use is O(1) in
+  clip duration. The mix stays on CPU.
+
+### Changed
+
+- `run_separation_gpu` computes the normalization peak without a full `abs()` copy and reuses
+  buffers in place (in-place subtract/divide), cutting peak host RAM during separation.
+
 [2.5.0] (2026-06-26)
 --------------------
 

--- a/app/voice_separation.py
+++ b/app/voice_separation.py
@@ -103,8 +103,10 @@ def separate_vocal(
     if input_audio.ndim == 1:
         input_audio = np.asfortranarray([input_audio, input_audio])
 
-    # Convert mix to torch tensor and move to GPU
-    input_audio = torch.from_numpy(input_audio).to(device)
+    # Keep the full mix on CPU and move only the current chunk to the GPU inside the loop
+    # below. Moving the whole clip to VRAM here is O(n) in duration — a 2 h stereo clip is
+    # ~2.5 GB of VRAM before any inference, which OOMs the GPU on long files.
+    input_audio = torch.from_numpy(input_audio)
 
     margin = sample_rate if sample_rate < audio_chunk_size else audio_chunk_size
     samples = input_audio.shape[-1]
@@ -112,7 +114,8 @@ def separate_vocal(
     if chunks == 0 or samples < audio_chunk_size:
         audio_chunk_size = samples
 
-    # Pre-allocate chunks on GPU
+    # Slice the mix into overlapping chunks (CPU views; each is moved to the GPU one at a
+    # time inside the loop, so VRAM use is O(1) in clip duration).
     chunk_samples = []
     for skip in range(0, samples, audio_chunk_size):
         s_margin = 0 if skip == 0 else margin
@@ -129,6 +132,7 @@ def separate_vocal(
     amp_dtype = torch.float16 if precision == "fp16" else (torch.bfloat16 if precision == "bf16" else None)
 
     for chunk_mix_position, chunk_mix in enumerate(chunk_samples):
+        chunk_mix = chunk_mix.to(device)  # only this chunk lives in VRAM (O(1) in duration)
         n_sample = chunk_mix.shape[1]
         trim = n_fft // 2
         gen_size = chunk_size - 2 * trim
@@ -296,11 +300,15 @@ def run_separation_gpu(
         precision=precision,
     )
 
-    audio_vocals = audio - target_est if cfg.outputs_instrumental() else target_est
+    if cfg.outputs_instrumental():
+        # vocals = mix - instrumental; write into target_est's buffer to avoid a full extra copy
+        np.subtract(audio, target_est, out=target_est)
+    audio_vocals = target_est
 
-    peak = np.max(np.abs(audio_vocals))
+    # peak without allocating a full abs() copy of the signal (== np.abs(x).max() for real x)
+    peak = float(max(audio_vocals.max(), -audio_vocals.min()))
     if np.isfinite(peak) and peak > 1.0:
-        audio_vocals = audio_vocals / peak
+        audio_vocals /= peak  # in-place, no extra full-length copy
 
     soundfile.write(str(output_path), audio_vocals.T, samplerate=cfg.sample_rate)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-asr-webservice"
-version = "2.5.0"
+version = "2.5.1"
 description = "Whisper ASR Webservice is a general-purpose speech recognition webservice."
 requires-python = ">=3.10,<3.13"
 dependencies = [


### PR DESCRIPTION
## Problem

`separate_vocal` moved the **entire mix** to the GPU up front:
```python
input_audio = torch.from_numpy(input_audio).to(device)   # whole clip → VRAM
```
The per-chunk slices are views into that tensor, so even though inference is chunked, the full clip sits in VRAM the whole time. For a 2 h stereo clip that's **~2.5 GB of VRAM before any inference** → `RuntimeError: CUDA failed with error out of memory` on long files (seen in prod on the T4 nodes).

## Fix

- Keep the mix on **CPU**; move **only the current chunk** to the GPU inside the loop (`chunk_mix = chunk_mix.to(device)`). VRAM is now bounded by one ~30 s chunk regardless of clip length → **O(1) in duration**.
- `run_separation_gpu`: compute the normalization peak without a full `abs()` copy (`max(x.max(), -x.min())`) and do the instrumental subtract / divide **in place**, cutting peak host RAM.

**Numerically identical by construction**: same per-chunk STFT/model/iSTFT ops, same dtypes, same order; chunk slices are bit-identical whether sliced before or after the device move. The peak/subtract changes are algebraically equal to the originals.

## Verification

- Existing suite: **8 passed** (module imports clean; separation can't be unit-tested in this repo because `conftest.py` stubs `torch`).
- ⚠️ **Before building/rolling the image**, run this A/B on one GPU box to confirm bit-equivalence against v2.5.0 on a real clip:

```python
# on a box with the v2.5.1 code + GPU
import numpy as np, soundfile as sf
from app.voice_separation import separate_vocals_from_file
separate_vocals_from_file("sample.mp3", "new.wav")     # this branch
# compare new.wav against a v2.5.0-produced old.wav:
a,_ = sf.read("old.wav"); b,_ = sf.read("new.wav")
print("max abs diff:", np.max(np.abs(a[:min(len(a),len(b))] - b[:min(len(a),len(b))])))
# expect ~0 (fp rounding only)
```

## Scope / follow-up

This fixes the **VRAM** O(n) (the CUDA OOM). The **host-RAM** output assembly (`chunked_sources` + `np.concatenate`) is still O(n) — full streaming of the output to disk is a larger, correctness-sensitive change (instrumental subtraction + margin reassembly + peak handling) and is deferred to a separate PR that needs the same on-box A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)