### PR TITLE
docs: Cloud Build path for the GPU image (make build-gpu)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Build/release helpers for the Mediainbox GPU image.
+#
+# The GPU image is linux/amd64 (CUDA). Building it locally on an arm64 Mac uses QEMU
+# emulation, which makes the torch+CUDA install painfully slow. Prefer Cloud Build, which
+# builds natively on amd64 and pushes straight to Artifact Registry.
+
+REGISTRY ?= us-central1-docker.pkg.dev/cloud-logger-177603/mediainbox/whisper-asr-webservice-gpu
+# Version comes from pyproject.toml; override with `make build-gpu VERSION=x.y.z`.
+VERSION  ?= $(shell sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)
+
+.PHONY: build-gpu build-gpu-local
+
+## Build the GPU image on Google Cloud Build (native amd64) and push :$(VERSION) + :latest.
+build-gpu:
+	gcloud builds submit --config cloudbuild.gpu.yaml \
+	  --substitutions=_REGISTRY=$(REGISTRY),_VERSION=$(VERSION) .
+
+## Fallback: build locally with buildx (slow under QEMU on arm64; use only without gcloud).
+build-gpu-local:
+	docker buildx build --platform linux/amd64 -f Dockerfile.gpu \
+	  -t $(REGISTRY):$(VERSION) -t $(REGISTRY):latest --push .

--- a/cloudbuild.gpu.yaml
+++ b/cloudbuild.gpu.yaml
@@ -1,0 +1,25 @@
+# Cloud Build config for the GPU image (native linux/amd64 — no local QEMU emulation).
+# Usage:
+#   gcloud builds submit --config cloudbuild.gpu.yaml \
+#     --substitutions=_VERSION=2.5.1 .
+# _REGISTRY defaults to the Mediainbox Artifact Registry repo; override if needed.
+substitutions:
+  _REGISTRY: us-central1-docker.pkg.dev/cloud-logger-177603/mediainbox/whisper-asr-webservice-gpu
+  _VERSION: latest
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.gpu
+      - -t
+      - ${_REGISTRY}:${_VERSION}
+      - -t
+      - ${_REGISTRY}:latest
+      - .
+images:
+  - ${_REGISTRY}:${_VERSION}
+  - ${_REGISTRY}:latest
+options:
+  machineType: E2_HIGHCPU_8
+timeout: 3600s

--- a/docs/build.md
+++ b/docs/build.md
@@ -85,3 +85,30 @@ poetry run whisper-asr-webservice --host 0.0.0.0 --port 9000
     ```shell
     poetry build
     ```
+
+### Build & push the GPU image (Mediainbox / Artifact Registry)
+
+The GPU image is `linux/amd64` (CUDA). Building it locally on an Apple Silicon (arm64)
+Mac uses QEMU emulation, which makes the torch+CUDA install very slow (~10 min).
+Prefer **Cloud Build**, which builds natively on amd64 and pushes straight to Artifact
+Registry — minutes instead, and it doesn't tie up your machine or upload bandwidth.
+
+```shell
+# Version is read from pyproject.toml; pushes :<version> and :latest.
+make build-gpu
+
+# or pin a version explicitly:
+make build-gpu VERSION=2.5.1
+```
+
+`make build-gpu` runs `cloudbuild.gpu.yaml`. To build locally instead (slow under QEMU
+on arm64, only if `gcloud` is unavailable):
+
+```shell
+make build-gpu-local
+```
+
+!!! Note
+    Pushing a git tag (e.g. `v2.5.1`) also triggers `.github/workflows/docker-publish.yml`,
+    which builds and publishes to **DockerHub** — separate from the Artifact Registry image
+    produced by `make build-gpu`.


### PR DESCRIPTION
Documents and scripts the fast way to build/push the GPU image, after hitting ~10 min emulated builds locally.

- `make build-gpu` → builds on **Cloud Build** (native amd64) via `cloudbuild.gpu.yaml`, pushes `:<version>` (from pyproject) + `:latest` to Artifact Registry. No local QEMU, no local upload.
- `make build-gpu-local` → buildx fallback (slow under QEMU on arm64).
- `docs/build.md` section explaining the why + the DockerHub-vs-Artifact-Registry distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)