### PR TITLE
fix: 503 backpressure + scratch tmpdir bind mount

### DIFF
--- a/app/webservice.py
+++ b/app/webservice.py
@@ -258,6 +258,13 @@ async def asr(
 ):
     filename = getattr(audio_file, "filename", "") or "audio.wav"
 
+    if _transcribe_semaphore._value == 0:
+        from fastapi import Response
+        return Response(status_code=503, headers={"Retry-After": "5"})
+    if separate_vocals and _vocals_semaphore._value == 0:
+        from fastapi import Response
+        return Response(status_code=503, headers={"Retry-After": "5"})
+
     newrelic.agent.add_custom_attributes(
         {
             "asr.engine": CONFIG.ASR_ENGINE,

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -14,11 +14,13 @@ services:
               capabilities: [gpu]
     environment:
       - ASR_MODEL=base
+      - TMPDIR=/scratch
     ports:
       - "9000:9000"
     volumes:
       - ./app:/app/app
       - cache-whisper:/root/.cache
+      - /opt/whisper-scratch:/scratch
 
 volumes:
   cache-whisper:


### PR DESCRIPTION
## Summary

- **503 backpressure en `/asr`**: cuando todos los slots de `transcribe` (o `vocals`) están ocupados, devuelve `503 + Retry-After: 5` inmediatamente antes de leer el archivo. Permite que el LB en modo `IN_FLIGHT` deje de enviar tráfico al nodo saturado y distribuya hacia los que tienen capacidad.

- **TMPDIR → bind mount del host**: `TMPDIR=/scratch` + volumen `/opt/whisper-scratch:/scratch` saca los archivos temporales de `TemporaryDirectory` del overlay de Docker hacia el disco del host. Previene disk exhaustion cuando requests encolados con `separate_vocals=True` mantienen abiertos temp dirs con el audio completo.

## Deploy

En cada nodo antes de `docker compose up`:
```bash
mkdir -p /opt/whisper-scratch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)