### PR TITLE
fix: close TOCTOU gap in semaphore backpressure, add uvicorn concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changelog
 Unreleased
 ----------
 
+[2.5.3] (2026-07-01)
+--------------------
+
+### Fixed
+
+- The 503-on-full-capacity check for `/asr` was only evaluated once at request entry — a stale snapshot. Capacity could fill during upload I/O or an admission burst, and `asyncio.Semaphore` has no acquire timeout, so admitted requests piled up indefinitely in `_requests_active` waiting on `async with`. The check now runs immediately before each of the three semaphore acquisitions (decode, vocals, transcribe), including the previously-unchecked decode gate, so requests are rejected at the real moment of contention instead of queuing forever.
+- Added `UVICORN_LIMIT_CONCURRENCY` (uvicorn's native `limit_concurrency`) as a second line of defense against connection/FD exhaustion from traffic spikes, independent of the app-level semaphore gates.
+
 [2.5.2] (2026-06-28)
 --------------------
 

--- a/app/config.py
+++ b/app/config.py
@@ -69,3 +69,8 @@ class CONFIG:
     # decode N full clips into RAM at once even when TRANSCRIBE_CONCURRENCY is 1.
     # ponytail: fixed cap on concurrent decodes; raise per available host RAM, not per GPU.
     DECODE_CONCURRENCY = int(os.getenv("DECODE_CONCURRENCY", os.getenv("GPU_CONCURRENCY", 2)))
+
+    # Max concurrent HTTP connections accepted by uvicorn. Requests beyond this limit
+    # receive an immediate 503 at the transport layer — before any app code runs.
+    # Prevents FD exhaustion under traffic spikes. 0 = unlimited (uvicorn default).
+    UVICORN_LIMIT_CONCURRENCY = int(os.getenv("UVICORN_LIMIT_CONCURRENCY", 0)) or None

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -42,6 +42,19 @@ _transcribe_semaphore = asyncio.Semaphore(CONFIG.TRANSCRIBE_CONCURRENCY)
 # Without this gate, concurrent uploads decode all clips into RAM at once and OOM the host.
 _decode_semaphore    = asyncio.Semaphore(CONFIG.DECODE_CONCURRENCY)
 
+def _reject_if_full(sem: asyncio.Semaphore):
+    """Reject with 503 right at the point of use instead of queuing indefinitely
+    on `async with sem`. A single check at request entry is a stale snapshot —
+    capacity can fill during upload I/O or a burst of concurrent admissions
+    between the check and the actual acquire, and asyncio.Semaphore has no
+    acquire timeout, so admitted-but-blocked requests pile up in _requests_active
+    forever. Checking again immediately before each acquire closes that gap."""
+    if sem._value == 0:
+        from fastapi import Response
+        return Response(status_code=503, headers={"Retry-After": "5"})
+    return None
+
+
 _start_time = time.time()
 _requests_total = 0
 _requests_active = 0
@@ -317,6 +330,9 @@ async def asr(
                 ):
                     # CPU phase: decode audio and fetch cached model — no GPU needed.
                     # Decode is the RAM-heavy step, so it goes under the decode gate.
+                    if rejected := _reject_if_full(_decode_semaphore):
+                        _requests_active -= 1
+                        return rejected
                     async with _decode_semaphore:
                         audio_raw, vs_cfg, vs_model, vs_device = await asyncio.to_thread(
                             load_audio_for_separation,
@@ -324,6 +340,9 @@ async def asr(
                             model_id=CONFIG.VOICE_SEPARATION_MODEL,
                         )
                     # GPU phase: vocal separation inference
+                    if rejected := _reject_if_full(_vocals_semaphore):
+                        _requests_active -= 1
+                        return rejected
                     async with _vocals_semaphore:
                         await asyncio.to_thread(
                             run_separation_gpu,
@@ -340,6 +359,9 @@ async def asr(
                         newrelic.agent.FunctionTrace(name="asr.load_audio_vocals", group="ASR"),
                         timer("load_audio(vocals)", enabled=verbose),
                     ):
+                        if rejected := _reject_if_full(_decode_semaphore):
+                            _requests_active -= 1
+                            return rejected
                         async with _decode_semaphore:
                             audio_np = await asyncio.to_thread(load_audio, f_vocals, encode=True)
 
@@ -347,6 +369,9 @@ async def asr(
                     newrelic.agent.FunctionTrace(name="asr.transcribe", group="ASR"),
                     timer(f"transcribe({CONFIG.ASR_ENGINE})", enabled=verbose),
                 ):
+                    if rejected := _reject_if_full(_transcribe_semaphore):
+                        _requests_active -= 1
+                        return rejected
                     async with _transcribe_semaphore:
                         result = await asyncio.to_thread(
                             asr_model.transcribe,
@@ -364,6 +389,9 @@ async def asr(
             newrelic.agent.FunctionTrace(name="asr.load_audio_original", group="ASR"),
             timer("load_audio(original)", enabled=verbose),
         ):
+            if rejected := _reject_if_full(_decode_semaphore):
+                _requests_active -= 1
+                return rejected
             async with _decode_semaphore:
                 audio_np = await asyncio.to_thread(load_audio, audio_file.file, encode)
 
@@ -375,6 +403,9 @@ async def asr(
                 newrelic.agent.FunctionTrace(name="asr.transcribe", group="ASR"),
                 timer(f"transcribe({CONFIG.ASR_ENGINE})", enabled=verbose),
             ):
+                if rejected := _reject_if_full(_transcribe_semaphore):
+                    _requests_active -= 1
+                    return rejected
                 async with _transcribe_semaphore:
                     result = await asyncio.to_thread(
                         asr_model.transcribe,
@@ -486,7 +517,8 @@ async def detect_language(
 )
 @click.version_option(version=projectMetadata["Version"])
 def start(host: str, port: int, workers: int):
-    uvicorn.run("app.webservice:app", host=host, port=port, workers=workers)
+    uvicorn.run("app.webservice:app", host=host, port=port, workers=workers,
+                limit_concurrency=CONFIG.UVICORN_LIMIT_CONCURRENCY)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-asr-webservice"
-version = "2.5.2"
+version = "2.5.3"
 description = "Whisper ASR Webservice is a general-purpose speech recognition webservice."
 requires-python = ">=3.10,<3.13"
 dependencies = [

--- a/tests/test_asr_async.py
+++ b/tests/test_asr_async.py
@@ -162,7 +162,10 @@ def test_decode_concurrency_is_bounded(client):
         with ThreadPoolExecutor(max_workers=8) as pool:
             results = [f.result() for f in [pool.submit(fire) for _ in range(8)]]
 
-    assert all(r.status_code == 200 for r in results)
+    # Requests beyond capacity at acquire time are rejected with 503 (fast backpressure)
+    # instead of queuing indefinitely — so not all 8 are expected to return 200.
+    assert all(r.status_code in (200, 503) for r in results)
+    assert any(r.status_code == 200 for r in results), "no request got through at all"
     assert state["max"] <= limit, f"decode concurrency {state['max']} exceeded cap {limit}"
     if limit > 1:
         assert state["max"] > 1, "decode never ran in parallel; cap is not just serializing"


### PR DESCRIPTION
## Summary

Root-caused the `271 activos` seen on a production node despite the v2.5.2 503-backpressure fix already being deployed.

**The gap:** the 503-on-full check only ran once, at request entry — a stale snapshot. Between that check and the actual `async with sem:` acquire (which has no timeout), capacity could fill up (upload I/O takes time, and a burst of requests can all pass the check simultaneously when 1-2 slots are free). Admitted requests then queued indefinitely inside `_requests_active`, which is exactly the pileup observed in production.

**Fix:** run the same check immediately before each of the three real acquire points (decode, vocals, transcribe) instead of once at the top. Also adds the decode gate, which had no backpressure check at all before this change.

**Second line of defense:** `UVICORN_LIMIT_CONCURRENCY` (uvicorn's native `limit_concurrency`) rejects at the transport layer before the request even reaches the app, in case of a pathological traffic spike beyond what the app-level gates catch.

## Test plan

- [x] `pytest tests/test_asr_async.py` — updated `test_decode_concurrency_is_bounded` to expect a mix of 200/503 under a concurrent burst (previously assumed all requests eventually succeed by queuing, which is the exact bug this PR fixes)
- [ ] Deploy to one node and confirm `/stats` `requests.active` never exceeds `DECODE_CONCURRENCY + VOCALS_CONCURRENCY + TRANSCRIBE_CONCURRENCY` under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)